### PR TITLE
👌 Pull Request to merge Commits from feature/reset.css to main

### DIFF
--- a/src/lib/reset.css
+++ b/src/lib/reset.css
@@ -1,0 +1,47 @@
+*, *::before, *::after {
+	box-sizing: border-box;
+}
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+	height: 100%;
+	overflow: hidden;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,3 @@
 export const prerender = true;
+
+import '$lib/reset.css';


### PR DESCRIPTION
- Added reset.css to layout

This pull request adds reset.css, which is copied from https://meyerweb.com/eric/tools/css/reset. The following quote is taken from that page:

> The goal of a reset stylesheet is to reduce browser inconsistencies in things like default line heights, margins and font sizes of headings, and so on. The general reasoning behind this was [discussed in a May 2007 post](http://meyerweb.com/eric/thoughts/2007/04/18/reset-reasoning/), if you're interested. Reset styles quite often appear in CSS frameworks, and the original "meyerweb reset" found its way into [Blueprint](http://code.google.com/p/blueprintcss/), among others.